### PR TITLE
Mvp backend

### DIFF
--- a/backend/src/main/java/org/example/backend/controller/WichtelEventController.java
+++ b/backend/src/main/java/org/example/backend/controller/WichtelEventController.java
@@ -60,7 +60,7 @@ public class WichtelEventController {
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ResponseStatus(HttpStatus.CONFLICT)
     public String handleIllegalArgumentException(IllegalArgumentException exception) {
         return exception.getMessage();
     }

--- a/backend/src/main/java/org/example/backend/model/InvitationStatus.java
+++ b/backend/src/main/java/org/example/backend/model/InvitationStatus.java
@@ -4,4 +4,5 @@ public enum InvitationStatus {
     PENDING,
     DECLINED,
     ACCEPTED
+
 }

--- a/backend/src/main/java/org/example/backend/model/WichtelEvent.java
+++ b/backend/src/main/java/org/example/backend/model/WichtelEvent.java
@@ -27,4 +27,5 @@ public class WichtelEvent {
     LocalDateTime giftExchangeDate;
     List<WichtelParticipant> participants;
     Map<WichtelParticipant,WichtelParticipant> pairings;
+
 }

--- a/backend/src/main/java/org/example/backend/model/WichtelEventDTO.java
+++ b/backend/src/main/java/org/example/backend/model/WichtelEventDTO.java
@@ -26,4 +26,5 @@ public class WichtelEventDTO {
     @With
     LocalDateTime giftExchangeDate;
     List<WichtelParticipantDTO> participants;
+
 }

--- a/backend/src/main/java/org/example/backend/model/WichtelParticipant.java
+++ b/backend/src/main/java/org/example/backend/model/WichtelParticipant.java
@@ -15,4 +15,5 @@ public class WichtelParticipant {
     String wishList;
     @With
     String address;
+
 }

--- a/backend/src/main/java/org/example/backend/model/WichtelParticipantDTO.java
+++ b/backend/src/main/java/org/example/backend/model/WichtelParticipantDTO.java
@@ -9,4 +9,5 @@ import lombok.Data;
 public class WichtelParticipantDTO {
     WichtelUserDTO participant;
     InvitationStatus invitationStatus;
+
 }

--- a/backend/src/main/java/org/example/backend/repo/WichtelEventRepo.java
+++ b/backend/src/main/java/org/example/backend/repo/WichtelEventRepo.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface WichtelEventRepo extends MongoRepository<WichtelEvent,String> {
+
 }

--- a/backend/src/main/java/org/example/backend/service/WichtelEventService.java
+++ b/backend/src/main/java/org/example/backend/service/WichtelEventService.java
@@ -63,7 +63,7 @@ public class WichtelEventService {
                 .findFirst()
                 .orElseThrow(IllegalArgumentException::new);
         event.getParticipants().remove(oldParticipant);
-        event.getParticipants().add(new WichtelParticipant(user,participant.getInvitationStatus(),participant.getWishList(),participant.getAddress()));
+        event.getParticipants().add(new WichtelParticipant(user, participant.getInvitationStatus(), participant.getWishList(), participant.getAddress()));
         return toDTO(repo.save(event));
     }
 }

--- a/backend/src/main/java/org/example/backend/util/DTOConverter.java
+++ b/backend/src/main/java/org/example/backend/util/DTOConverter.java
@@ -2,6 +2,9 @@ package org.example.backend.util;
 
 import org.example.backend.model.*;
 
+import java.util.List;
+import java.util.Map;
+
 
 public class DTOConverter {
 

--- a/backend/src/main/java/org/example/backend/util/DTOConverter.java
+++ b/backend/src/main/java/org/example/backend/util/DTOConverter.java
@@ -20,7 +20,7 @@ public class DTOConverter {
     }
 
     public static WichtelParticipant fromDTO(WichtelParticipantDTO dto, String id, String address, String wishList) {
-        return new WichtelParticipant(fromDTO(dto.getParticipant(), id), dto.getInvitationStatus(), wishList, address);
+        return new WichtelParticipant(fromDTO(dto.getParticipant(), id), dto.getInvitationStatus(), address, wishList);
     }
 
     public static WichtelEventDTO toDTO(WichtelEvent event) {

--- a/backend/src/test/java/org/example/backend/integration/WichtelEventControllerIntegrationTest.java
+++ b/backend/src/test/java/org/example/backend/integration/WichtelEventControllerIntegrationTest.java
@@ -1,0 +1,328 @@
+package org.example.backend.integration;
+
+import org.example.backend.model.InvitationStatus;
+import org.example.backend.model.WichtelEvent;
+import org.example.backend.model.WichtelParticipant;
+import org.example.backend.model.WichtelUser;
+import org.example.backend.repo.WichtelEventRepo;
+import org.example.backend.repo.WichtelUserRepo;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class WichtelEventControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private WichtelEventRepo repo;
+
+    @Autowired
+    private WichtelUserRepo userRepo;
+
+    @DirtiesContext
+    @Test
+    void findAll_returnsEmpty_ifDBEmpty() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/event"))
+                .andExpect(status().isOk())
+                .andExpect(content().json("[]"));
+    }
+
+    @DirtiesContext
+    @Test
+    void findAll_getsEvent_ifEventInDB() throws Exception {
+        WichtelEvent event = new WichtelEvent("id", new WichtelUser("1", "name", "email"), "test title", "", "", "", null, null, Collections.emptyList(), new HashMap<>());
+
+        repo.save(event);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/event"))
+                .andExpect(status().isOk())
+                .andExpect(content().json("""
+                        [
+                            {
+                                "organizer": {
+                                                "name": "name",
+                                                "email": "email"
+                                              },
+                                "title": "test title",
+                                "description":"",
+                                "budget":"",
+                                "image":"",
+                                "drawDate":null,
+                                "giftExchangeDate":null,
+                                "participants":[]
+                        
+                            }
+                        ]
+                        """));
+    }
+
+    @DirtiesContext
+    @Test
+    void createEvent_throws_ifCreatingUserDoesNotExist() throws Exception{
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/event/1"))
+                .andExpect(status().isNotFound());
+    }
+
+    @DirtiesContext
+    @Test
+    void createEvent_createsAnEvent_ifCreatingUserExists() throws Exception{
+        userRepo.save(new WichtelUser("1","name","email"));
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/event/1"))
+                .andExpect(status().isOk());
+        assertEquals(1,repo.count());
+    }
+
+    @DirtiesContext
+    @Test
+    void findById_shouldThrow_onEmptyDB() throws Exception{
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/event/1"))
+                .andExpect(status().isNotFound());
+    }
+
+    @DirtiesContext
+    @Test
+    void findById_shouldReturnUser_ifInDB() throws Exception{
+        WichtelEvent event = new WichtelEvent("id", new WichtelUser("1", "name", "email"), "test title", "", "", "", null, null, Collections.emptyList(), new HashMap<>());
+        repo.save(event);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/event/id"))
+                .andExpect(status().isOk())
+                .andExpect(content().json("""
+                                {
+                                "organizer": {
+                                                "name": "name",
+                                                "email": "email"
+                                              },
+                                "title": "test title",
+                                "description":"",
+                                "budget":"",
+                                "image":"",
+                                "drawDate":null,
+                                "giftExchangeDate":null,
+                                "participants":[]
+                                }
+                            """));
+    }
+
+    @DirtiesContext
+    @Test
+    void delete_shouldDeleteEvent() throws Exception{
+        WichtelEvent event = new WichtelEvent("id", new WichtelUser("1", "name", "email"), "test title", "", "", "", null, null, Collections.emptyList(), new HashMap<>());
+        repo.save(event);
+
+        mockMvc.perform(MockMvcRequestBuilders.delete("/api/event/id"))
+                .andExpect(status().isOk());
+
+        assertTrue(repo.findById("id").isEmpty());
+    }
+
+    @DirtiesContext
+    @Test
+    void update_shouldThrow_ifEventDoesntExist() throws Exception{
+        mockMvc.perform(MockMvcRequestBuilders.put("/api/event/id")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                "organizer": {
+                                                "name": "name",
+                                                "email": "email"
+                                              },
+                                "title": "test title",
+                                "description":"",
+                                "budget":"",
+                                "image":"",
+                                "drawDate":null,
+                                "giftExchangeDate":null,
+                                "participants":[]
+                                }"""))
+                .andExpect(status().isNotFound());
+    }
+
+    @DirtiesContext
+    @Test
+    void update_shouldUpdate_ifEventInDB() throws Exception{
+        WichtelEvent event = new WichtelEvent("id", new WichtelUser("1", "name", "email"), "", "", "", "", null, null, Collections.emptyList(), new HashMap<>());
+        repo.save(event);
+
+        mockMvc.perform(MockMvcRequestBuilders.put("/api/event/id")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                                {
+                                "organizer": {
+                                                "name": "name",
+                                                "email": "email"
+                                              },
+                                "title": "test title",
+                                "description":"",
+                                "budget":"",
+                                "image":"",
+                                "drawDate":null,
+                                "giftExchangeDate":null,
+                                "participants":[]
+                                }"""))
+                .andExpect(status().isOk())
+                .andExpect(content().json("""
+                                {
+                                "organizer": {
+                                                "name": "name",
+                                                "email": "email"
+                                              },
+                                "title": "test title",
+                                "description":"",
+                                "budget":"",
+                                "image":"",
+                                "drawDate":null,
+                                "giftExchangeDate":null,
+                                "participants":[]
+                                }"""));
+
+        assertEquals("test title",repo.findById("id").orElseThrow().getTitle());
+    }
+
+    @DirtiesContext
+    @Test
+    void addParticipant_shouldThrow_ifUserDoesntExistInDB() throws Exception{
+        WichtelEvent event = new WichtelEvent("id", new WichtelUser("1", "name", "email"), "", "", "", "", null, null, new ArrayList<>(), new HashMap<>());
+        repo.save(event);
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/event/id/1"))
+                .andExpect(status().isNotFound());
+    }
+
+    @DirtiesContext
+    @Test
+    void addParticipant_shouldThrow_ifEventDoesntExistInDB() throws Exception{
+        userRepo.save(new WichtelUser("1", "name", "email"));
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/event/id/1"))
+                .andExpect(status().isNotFound());
+    }
+
+    @DirtiesContext
+    @Test
+    void addParticipant_shouldThrow_ifAlreadyParticipating() throws Exception{
+        WichtelUser user = new WichtelUser("1", "name", "email");
+        userRepo.save(user);
+        WichtelEvent event = new WichtelEvent("id", user, "", "", "", "", null, null, new ArrayList<>(List.of(new WichtelParticipant(user, InvitationStatus.PENDING, "", ""))), new HashMap<>());
+        repo.save(event);
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/event/id/1"))
+                .andExpect(status().isConflict());
+    }
+
+    @DirtiesContext
+    @Test
+    void addParticipant_shouldAdd_ifRequestValid() throws Exception{
+        WichtelUser user = new WichtelUser("1", "name", "email");
+        userRepo.save(user);
+        WichtelEvent event = new WichtelEvent("id", user, "", "", "", "", null, null, new ArrayList<>(), new HashMap<>());
+        repo.save(event);
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/event/id/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().json("""
+                            {
+                            "participants": [{"participant":{"name":"name","email":"email"},"invitationStatus":"PENDING"}]
+                            }
+                            """));
+    }
+
+    @DirtiesContext
+    @Test
+    void updateParticipant_shouldThrow_ifUserDoesntExistInDB() throws Exception{
+        WichtelUser user = new WichtelUser("1", "name", "email");
+        WichtelEvent event = new WichtelEvent("id", user, "", "", "", "", null, null, new ArrayList<>(List.of(new WichtelParticipant(user, InvitationStatus.PENDING, "", ""))), new HashMap<>());
+        repo.save(event);
+
+        mockMvc.perform(MockMvcRequestBuilders.put("/api/event/id/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                      "participant": { "id": 1,"name": "name","email":"email"},
+                                      "invitationStatus": "PENDING",
+                                      "wishList": "",
+                                      "address": ""
+                                }"""))
+                .andExpect(status().isNotFound());
+    }
+
+    @DirtiesContext
+    @Test
+    void updateParticipant_shouldThrow_ifEventDoesntExist() throws Exception{
+        WichtelUser user = new WichtelUser("1", "name", "email");
+        userRepo.save(user);
+
+        mockMvc.perform(MockMvcRequestBuilders.put("/api/event/id/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                      "participant": { "id": 1,"name": "name","email":"email"},
+                                      "invitationStatus": "PENDING",
+                                      "wishList": "",
+                                      "address": ""
+                                }"""))
+                .andExpect(status().isNotFound());
+    }
+
+    @DirtiesContext
+    @Test
+    void updateParticipant_shouldThrow_ifUserIsNotParticipating() throws Exception{
+        WichtelUser user = new WichtelUser("1", "name", "email");
+        userRepo.save(user);
+        WichtelEvent event = new WichtelEvent("id", user, "", "", "", "", null, null, new ArrayList<>(), new HashMap<>());
+        repo.save(event);
+
+        mockMvc.perform(MockMvcRequestBuilders.put("/api/event/id/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                      "participant": { "id": 1,"name": "name","email":"email"},
+                                      "invitationStatus": "PENDING",
+                                      "wishList": "",
+                                      "address": ""
+                                }"""))
+                .andExpect(status().isConflict());
+    }
+
+    @DirtiesContext
+    @Test
+    void updateParticipant_shouldUpdate_ifRequestValid() throws Exception{
+        WichtelUser user = new WichtelUser("1", "name", "email");
+        userRepo.save(user);
+        WichtelEvent event = new WichtelEvent("id", user, "", "", "", "", null, null, new ArrayList<>(List.of(new WichtelParticipant(user,InvitationStatus.PENDING,"",""))), new HashMap<>());
+        repo.save(event);
+
+        mockMvc.perform(MockMvcRequestBuilders.put("/api/event/id/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                      "participant": { "id": 1,"name": "name","email":"email"},
+                                      "invitationStatus": "ACCEPTED",
+                                      "wishList": "",
+                                      "address": ""
+                                }"""))
+                .andExpect(status().isOk())
+                .andExpect(content().json("""
+                                {
+                                      "participants": [{
+                                                        "participant": { "name": "name","email":"email"},
+                                                        "invitationStatus": "ACCEPTED"}
+                                                        ]}"""));
+    }
+}

--- a/backend/src/test/java/org/example/backend/integration/WichtelUserControllerIntegrationTest.java
+++ b/backend/src/test/java/org/example/backend/integration/WichtelUserControllerIntegrationTest.java
@@ -57,7 +57,7 @@ public class WichtelUserControllerIntegrationTest {
     @DirtiesContext
     @Test
     void findById_shouldThrow_onEmptyDB() throws Exception{
-        mockMvc.perform(MockMvcRequestBuilders.get("/api/1"))
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/user/1"))
                 .andExpect(status().isNotFound());
     }
     @DirtiesContext

--- a/backend/src/test/java/org/example/backend/service/WichtelEventServiceTest.java
+++ b/backend/src/test/java/org/example/backend/service/WichtelEventServiceTest.java
@@ -1,0 +1,108 @@
+package org.example.backend.service;
+
+import org.example.backend.model.*;
+import org.example.backend.repo.WichtelEventRepo;
+import org.example.backend.repo.WichtelUserRepo;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.*;
+
+import static org.example.backend.util.DTOConverter.fromDTO;
+import static org.example.backend.util.DTOConverter.toDTO;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class WichtelEventServiceTest {
+    private final WichtelEventRepo repo = mock(WichtelEventRepo.class);
+    private final IdService idService = mock(IdService.class);
+    private final WichtelUserService userService = mock(WichtelUserService.class);
+    private final WichtelEventService service = new WichtelEventService(repo, idService, userService);
+
+    @Test
+    void createEmptyEvent_createsEvent() {
+        when(userService.findById("1")).thenReturn(new WichtelUser("1", "name", "email"));
+        when(idService.generateId()).thenReturn("id");
+        WichtelEvent expected = new WichtelEvent("id", new WichtelUser("1", "name", "email"), "", "", "", "", null, null, Collections.emptyList(), new HashMap<>());
+        when(repo.save(any(WichtelEvent.class))).thenReturn(expected);
+        String actual = service.createEmptyEvent("1");
+        assertEquals(expected.getId(), actual);
+    }
+
+    @Test
+    void findById_throws_ifEventNotInDB() {
+        when(repo.findById("1")).thenReturn(Optional.empty());
+        assertThrows(NoSuchElementException.class, () -> service.findById("1"));
+        verify(repo).findById("1");
+    }
+
+    @Test
+    void findById_findsEvent_ifInDB() {
+        WichtelEvent expected = new WichtelEvent("id", new WichtelUser("1", "name", "email"), "", "", "", "", null, null, Collections.emptyList(), new HashMap<>());
+        when(repo.findById("id")).thenReturn(Optional.of(expected));
+        WichtelEventDTO actual = service.findById("id");
+        verify(repo).findById("id");
+        assertEquals(toDTO(expected), actual);
+    }
+
+    @Test
+    void update() {
+        WichtelEvent previous = new WichtelEvent("id", new WichtelUser("1", "name", "email"), "", "", "", "", null, null, Collections.emptyList(), new HashMap<>());
+        WichtelUser organizer = new WichtelUser("1","name","email");
+        WichtelEventDTO updated = new WichtelEventDTO(toDTO(organizer),
+                "title",
+                "description",
+                "budged",
+                "image",
+                LocalDateTime.now(),
+                LocalDateTime.now(),
+                Collections.emptyList());
+        when(repo.findById("id")).thenReturn(Optional.of(previous));
+        when(repo.save(any(WichtelEvent.class))).thenAnswer(input -> input.getArgument(0));
+        WichtelEventDTO actual = service.update(updated,"id");
+        verify(repo).save(any(WichtelEvent.class));
+        assertEquals(updated,actual);
+    }
+
+    @Test
+    void addParticipant_throws_ifAlreadyInEvent() {
+        WichtelUser user = new WichtelUser("1","name","email");
+        WichtelEvent event = new WichtelEvent("id", new WichtelUser("1", "name", "email"), "", "", "", "", null, null, List.of(new WichtelParticipant(user,null,null,null)), new HashMap<>());
+        when(repo.findById("id")).thenReturn(Optional.of(event));
+        assertThrows(IllegalArgumentException.class,() -> service.addParticipant("id","1"));
+    }
+
+    @Test
+    void addParticipant_addsUserToEvent_ifNotAlreadyPresent() {
+        WichtelUser user = new WichtelUser("1","name","email");
+        WichtelUser secondUser = new WichtelUser("2","name2","email2");
+        WichtelEvent event = new WichtelEvent("id", new WichtelUser("1", "name", "email"), "", "", "", "", null, null, new ArrayList<>(Arrays.asList(new WichtelParticipant(user,null,null,null))), new HashMap<>());
+        when(repo.findById("id")).thenReturn(Optional.of(event));
+        when(userService.findById("2")).thenReturn(secondUser);
+        when(repo.save(any(WichtelEvent.class))).thenAnswer(input -> input.getArgument(0));
+        WichtelEventDTO actual = service.addParticipant("id","2");
+        verify(repo).save(any(WichtelEvent.class));
+        assertEquals(2,actual.getParticipants().size());
+    }
+
+    @Test
+    void updateParticipant_throws_ifUserIsNotInEvent() {
+        WichtelUser user = new WichtelUser("1","name","email");
+        WichtelEvent event = new WichtelEvent("id", new WichtelUser("1", "name", "email"), "", "", "", "", null, null, List.of(new WichtelParticipant(user,null,null,null)), new HashMap<>());
+        when(repo.findById("id")).thenReturn(Optional.of(event));
+        assertThrows(IllegalArgumentException.class,() -> service.updateParticipant("id",new WichtelParticipant(null,null,null,null),"2"));
+    }
+
+    @Test
+    void updateParticipant_updates_ifUserIsInEvent(){
+        WichtelUser user = new WichtelUser("1","name","email");
+        WichtelEvent event = new WichtelEvent("id", new WichtelUser("1", "name", "email"), "", "", "", "", null, null, new ArrayList<>(Arrays.asList(new WichtelParticipant(user,InvitationStatus.PENDING,"",""))), new HashMap<>());
+        when(repo.findById("id")).thenReturn(Optional.of(event));
+        when(userService.findById("1")).thenReturn(user);
+        when(repo.save(any(WichtelEvent.class))).thenAnswer(input -> input.getArgument(0));
+        WichtelParticipant updated = new WichtelParticipant(user,InvitationStatus.ACCEPTED,"","");
+        WichtelEventDTO actual = service.updateParticipant("id",updated,"1");
+        assertEquals(toDTO(updated),actual.getParticipants().getFirst());
+    }
+}

--- a/backend/src/test/java/org/example/backend/service/WichtelUserServiceTest.java
+++ b/backend/src/test/java/org/example/backend/service/WichtelUserServiceTest.java
@@ -47,8 +47,6 @@ class WichtelUserServiceTest {
         WichtelUser actual = service.save(dto);
         verify(repo).save(any(WichtelUser.class));
         assertEquals(expected,actual);
-
-
     }
 
     @Test

--- a/backend/src/test/java/org/example/backend/util/DTOConverterTest.java
+++ b/backend/src/test/java/org/example/backend/util/DTOConverterTest.java
@@ -1,8 +1,11 @@
 package org.example.backend.util;
 
-import org.example.backend.model.WichtelUser;
-import org.example.backend.model.WichtelUserDTO;
+import org.example.backend.model.*;
 import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
 
 import static org.example.backend.util.DTOConverter.fromDTO;
 import static org.example.backend.util.DTOConverter.toDTO;
@@ -18,4 +21,28 @@ class DTOConverterTest {
         assertEquals(expected,actual);
     }
 
+    @Test
+    void wichtelParticipantConverter() {
+        WichtelUser user = new WichtelUser("1","name","email");
+        WichtelParticipant expected = new WichtelParticipant(user, InvitationStatus.PENDING,"wishList","address");
+        WichtelParticipantDTO dto = toDTO(expected);
+        WichtelParticipant actual = fromDTO(dto,user.getId(),"wishList","address");
+        assertEquals(expected,actual);
+    }
+
+    @Test
+    void wichtelEventConverter() {
+        WichtelUser user = new WichtelUser("1","name","email");
+        WichtelEvent expected = new WichtelEvent("id",user,
+                "title",
+                "description",
+                "budget",
+                "image",
+                LocalDateTime.now(),
+                LocalDateTime.now(),
+                List.of(new WichtelParticipant(user,InvitationStatus.PENDING,"wishList","address")),
+                new HashMap<>());
+        WichtelEventDTO dto = toDTO(expected);
+        WichtelEvent actual = fromDTO(dto,"id",user,List.of(new WichtelParticipant(user,InvitationStatus.PENDING,"wishList","address")),new HashMap<>());
+    }
 }

--- a/backend/src/test/java/org/example/backend/util/DTOConverterTest.java
+++ b/backend/src/test/java/org/example/backend/util/DTOConverterTest.java
@@ -44,5 +44,6 @@ class DTOConverterTest {
                 new HashMap<>());
         WichtelEventDTO dto = toDTO(expected);
         WichtelEvent actual = fromDTO(dto,"id",user,List.of(new WichtelParticipant(user,InvitationStatus.PENDING,"wishList","address")),new HashMap<>());
+        assertEquals(expected,actual);
     }
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,5 +9,7 @@ sonar.organization=jreinhard847
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=./frontend/src
 
+sonar.exclusions=./backend/src/main/java/org/example/backend/model/*
+
 # Encoding of the source code. Default is default system encoding
 #sonar.sourceEncoding=UTF-8

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,7 +9,7 @@ sonar.organization=jreinhard847
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=./frontend/src
 
-sonar.exclusions=./backend/src/main/java/org/example/backend/model/*
+sonar.exclusions=**/model/*
 
 # Encoding of the source code. Default is default system encoding
 #sonar.sourceEncoding=UTF-8

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,7 +9,8 @@ sonar.organization=jreinhard847
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=./frontend/src
 
-sonar.exclusions=**/model/*
+sonar.exclusions=backend/src/main/java/org/example/backend/model/**
+
 
 # Encoding of the source code. Default is default system encoding
 #sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
Kurze Erklärung der Endpunkte:
POST("/api/event/{id}): Erstellt ein neues WichtelEvent und speichert es in der DB. Die übergebene ID is die ID des Veranstalters(wird später wahrscheinlich per Login mit SecurityContext eingelesen und brauch dann keine Übergabe mehr). Returnt die ID des erstellten Events.
GET("/api/event): Gibt eine Liste mit allen Events als DTO zurück.
GET("/api/event/{id}): Gibt das Event mit der ID als DTO zurück.
PUT("/api/event/{id}"): Updatet das Event mit der ID mit den Werten aus dem RequestBody, mit der Ausnahme vom Veranstalter, der Liste der Teilnehmer und den Wichtelpaarungen.
DELETE("/api/event/{id}"): Löscht das Event mit der ID. Kann aktuell jeder der die ID kennt, später soll das nur gehen wenn der eingeloggte User der Veranstalter ist.
POST("/api/event/{eventId}/{userId}"): Fügt den User mit der userId als Teilnehmer zum Event mit eventId hinzu. Throwt, wenn User oder event nicht existieren, oder der User bereits teilnimmt.
POST("/api/event/{eventId}/{userId}"): Updated die Werte vom User mit userId als Teilnehmer vom Event mit eventId.Throwt, wenn User oder event nicht existieren, oder der User nicht am Event teilnimmt.

Bei den Tests sind IDs von Events immer "id" und von WichtelUsern immer "1" oder "2".